### PR TITLE
Mark chardet noarch/chardet-3.0.4-py_1004 broken

### DIFF
--- a/pkgs/chardet.txt
+++ b/pkgs/chardet.txt
@@ -1,0 +1,1 @@
+noarch/chardet-3.0.4-py_1004.tar.bz2


### PR DESCRIPTION
See: https://github.com/conda-forge/chardet-feedstock/pull/19