### PR TITLE
Add v1.2.5 to be marked broken

### DIFF
--- a/pkgs/gpi.txt
+++ b/pkgs/gpi.txt
@@ -1,0 +1,2 @@
+noarch/gpi-1.2.5-py_1.tar.bz2
+noarch/gpi-1.2.5-py_0.tar.bz2


### PR DESCRIPTION
v1.2.5 has a critical bug that prevented building a downstream package.