### PR TITLE
Remove the openmpi package with CUDA-awareness enabled

### DIFF
--- a/pkgs/openmpi.txt
+++ b/pkgs/openmpi.txt
@@ -1,0 +1,1 @@
+linux-64/openmpi-4.0.2-hdf1f1ad_3.tar.bz2


### PR DESCRIPTION
In conda-forge/openmpi-feedstock#56 we temporarily disabled (but still built) the support for CUDA awareness. This is to remove the package that enabled the support by default.

cc: @jakirkham @dalcinl 