### PR TITLE
Mark Spyder 4.1.1 build 0 as broken

### DIFF
--- a/pkgs/spyder.txt
+++ b/pkgs/spyder.txt
@@ -1,0 +1,12 @@
+win-64/spyder-4.1.1-py38h32f6830_0.tar.bz2
+win-64/spyder-4.1.1-py36h9f0ad1d_0.tar.bz2
+win-64/spyder-4.1.1-py27h8c360ce_0.tar.bz2
+win-64/spyder-4.1.1-py37hc8dfbb8_0.tar.bz2
+osx-64/spyder-4.1.1-py27h8c360ce_0.tar.bz2
+osx-64/spyder-4.1.1-py38h32f6830_0.tar.bz2
+osx-64/spyder-4.1.1-py37hc8dfbb8_0.tar.bz2
+osx-64/spyder-4.1.1-py36h9f0ad1d_0.tar.bz2
+linux-64/spyder-4.1.1-py36h9f0ad1d_0.tar.bz2
+linux-64/spyder-4.1.1-py38h32f6830_0.tar.bz2
+linux-64/spyder-4.1.1-py37hc8dfbb8_0.tar.bz2
+linux-64/spyder-4.1.1-py27h8c360ce_0.tar.bz2


### PR DESCRIPTION
This package has the wrong Jedi dependency. See https://github.com/conda-forge/spyder-feedstock/pull/79 for the fix.

Build 1 is already up with the fix.