### PR TITLE
Mark gwosc-0.5.1 as broken

### DIFF
--- a/pkgs/gwosc-0.5.1.txt
+++ b/pkgs/gwosc-0.5.1.txt
@@ -1,0 +1,1 @@
+noarch/gwosc-0.5.1-pyh8c360ce_0.tar.bz2


### PR DESCRIPTION
gwosc-0.5.1 was released without proper python version information, this was fixed in 0.5.2.