### PR TITLE
Mark libvorbis 1.3.6 build 0 as broken

### DIFF
--- a/pkgs/libvorbis.txt
+++ b/pkgs/libvorbis.txt
@@ -1,0 +1,5 @@
+linux-aarch64/libvorbis-1.3.6-hebb1f50_0.tar.bz2
+linux-ppc64le/libvorbis-1.3.6-h1d8a796_0.tar.bz2
+linux-64/libvorbis-1.3.6-hebb1f50_0.tar.bz2
+osx-64/libvorbis-1.3.6-hdfa65fd_0.tar.bz2
+win-64/libvorbis-1.3.6-h90ea4c2_0.tar.bz2


### PR DESCRIPTION
cc. @dschreij 