### PR TITLE
Remove some CuPy v7.2.0 packages

### DIFF
--- a/pkgs/cupy.txt
+++ b/pkgs/cupy.txt
@@ -1,18 +1,21 @@
+# PyPy builds (build no.2)
 linux-64/cupy-7.2.0-py36hf411039_2.tar.bz2
 linux-64/cupy-7.2.0-py36he7af1ec_2.tar.bz2
 linux-64/cupy-7.2.0-py36hbfcebc9_2.tar.bz2
 linux-64/cupy-7.2.0-py36h6e251b3_2.tar.bz2
 
+# PyPy builds (build no.3)
 linux-64/cupy-7.2.0-py36hf411039_3.tar.bz2
 linux-64/cupy-7.2.0-py36he7af1ec_3.tar.bz2
 linux-64/cupy-7.2.0-py36hbfcebc9_3.tar.bz2
 linux-64/cupy-7.2.0-py36h6e251b3_3.tar.bz2
 
-
+# CUDA 10.2 + CPython builds (build no.1)
 linux-64/cupy-7.2.0-py38h05764e2_1.tar.bz2
 linux-64/cupy-7.2.0-py37h05764e2_1.tar.bz2
 linux-64/cupy-7.2.0-py36h05764e2_1.tar.bz2
 
+# CUDA 10.2 + CPython builds (build no.2)
 linux-64/cupy-7.2.0-py38hb1193b0_2.tar.bz2
 linux-64/cupy-7.2.0-py37h940342b_2.tar.bz2
 linux-64/cupy-7.2.0-py36h4445f8d_2.tar.bz2

--- a/pkgs/cupy.txt
+++ b/pkgs/cupy.txt
@@ -1,0 +1,9 @@
+linux-64/cupy-7.2.0-py36hf411039_2.tar.bz2
+linux-64/cupy-7.2.0-py36he7af1ec_2.tar.bz2
+linux-64/cupy-7.2.0-py36hbfcebc9_2.tar.bz2
+linux-64/cupy-7.2.0-py36h6e251b3_2.tar.bz2
+
+linux-64/cupy-7.2.0-py36hf411039_3.tar.bz2
+linux-64/cupy-7.2.0-py36he7af1ec_3.tar.bz2
+linux-64/cupy-7.2.0-py36hbfcebc9_3.tar.bz2
+linux-64/cupy-7.2.0-py36h6e251b3_3.tar.bz2

--- a/pkgs/cupy.txt
+++ b/pkgs/cupy.txt
@@ -7,3 +7,12 @@ linux-64/cupy-7.2.0-py36hf411039_3.tar.bz2
 linux-64/cupy-7.2.0-py36he7af1ec_3.tar.bz2
 linux-64/cupy-7.2.0-py36hbfcebc9_3.tar.bz2
 linux-64/cupy-7.2.0-py36h6e251b3_3.tar.bz2
+
+
+linux-64/cupy-7.2.0-py38h05764e2_1.tar.bz2
+linux-64/cupy-7.2.0-py37h05764e2_1.tar.bz2
+linux-64/cupy-7.2.0-py36h05764e2_1.tar.bz2
+
+linux-64/cupy-7.2.0-py38hb1193b0_2.tar.bz2
+linux-64/cupy-7.2.0-py37h940342b_2.tar.bz2
+linux-64/cupy-7.2.0-py36h4445f8d_2.tar.bz2


### PR DESCRIPTION
Not sure if we can leave comments in the txt file, so let me explain here:

- The first two batches are PyPy builds (build numbers 2 & 3 x CUDA versions 9.2, 10.0, 10.1, 10.2). They should be marked broken because of the observation https://github.com/conda-forge/cupy-feedstock/issues/43#issuecomment-603032749.
- The rest two batches are CUDA 10.2 builds (build number 1 & 2 x CPython 3.6, 3.7, 3.8). They are broken because the fp16 headers are missed (conda-forge/cupy-feedstock#41).

@jakirkham, could you confirm the list is correct? Thanks!