### PR TITLE
svgwrite packages broken by py2 removal

### DIFF
--- a/pkgs/svgwrite.txt
+++ b/pkgs/svgwrite.txt
@@ -1,0 +1,2 @@
+noarch/svgwrite-1.4-pyh9f0ad1d_0.tar.bz2
+linux-64/svgwrite-1.4-py36h9f0ad1d_1.tar.bz2


### PR DESCRIPTION
Svgwrite 1.4 needs Python 3.6+, and the recipe did not initially remove support for Python 2. This removes the broken package built initially, and the broken package built by a botched effort to fix the issue.

See https://github.com/conda-forge/svgwrite-feedstock/issues/6

@dwhswenson do you agree with marking these packages as broken?