### PR TITLE
Mark conda-build=3.18.12 as broken in Windows

### DIFF
--- a/pkgs/conda-build-3.18.12-windows.txt
+++ b/pkgs/conda-build-3.18.12-windows.txt
@@ -1,0 +1,4 @@
+win-64/conda-build-3.18.12-py37hc8dfbb8_2.tar.bz2
+win-64/conda-build-3.18.12-py36h9f0ad1d_2.tar.bz2
+win-64/conda-build-3.18.12-py27_1.tar.bz2
+win-64/conda-build-3.18.12-py27_0.tar.bz2


### PR DESCRIPTION
Breaking behavior was fixed in CB 3.19, but that's been marked as broken too, so...

Refs:
* https://github.com/conda/conda-build/issues/3899
* https://gitter.im/conda-forge/conda-forge.github.io?at=5e8461aab5496402d8acb5ea

