### PR TITLE
Remove Open MPI v4.0.3 for OS X

### DIFF
--- a/pkgs/openmpi.txt
+++ b/pkgs/openmpi.txt
@@ -1,0 +1,1 @@
+osx-64/openmpi-4.0.3-hed52333_0.tar.bz2


### PR DESCRIPTION
On OS X we learned that there's a cleanup failure in the fresh v4.0.3, see https://github.com/conda-forge/openmpi-feedstock/pull/57#issuecomment-610678486. We are still discussing what to do for OS X, and in the meanwhile it's best to remove the OS X build.

cc: @dalcinl