### PR TITLE
Mark terraform-provider-azurerm 2.5.0 for win-64 as broken

### DIFF
--- a/pkgs/terraform-provider-azurerm.txt
+++ b/pkgs/terraform-provider-azurerm.txt
@@ -1,0 +1,2 @@
+ win-64/terraform-provider-azurerm-2.5.0-h33c4730_0.tar.bz2
+ 


### PR DESCRIPTION
Package is empty

