### PR TITLE
Mark cloudpickle-1.4.0-pyh9f0ad1d_0 as broken

### DIFF
--- a/pkgs/cloudpickle.txt
+++ b/pkgs/cloudpickle.txt
@@ -1,0 +1,1 @@
+noarch/cloudpickle-1.4.0-pyh9f0ad1d_0.tar.bz2


### PR DESCRIPTION
Unfortunately this version is Python 3 only but we did not add the necessary metadata to make it so on the `conda-forge` channel.

cc @ogrisel
