### PR TITLE
mark  osx-64/freeimage-3.18.0-h4a8c4bd_0 as broken

### DIFF
--- a/pkgs/freeimage.txt
+++ b/pkgs/freeimage.txt
@@ -1,0 +1,1 @@
+osx-64/freeimage-3.18.0-h4a8c4bd_0.tar.bz2


### PR DESCRIPTION
we encountered some linker issues with occt. Somehow the older build is used at runtime while the newer package is used during the build.
https://github.com/conda-forge/occt-feedstock/issues/42