### PR TITLE
Remove CuPy builds with a bug in activate/deactivate scripts

### DIFF
--- a/pkgs/cupy.txt
+++ b/pkgs/cupy.txt
@@ -1,0 +1,31 @@
+# v7.4.0 build 1
+linux-64/cupy-7.4.0-py38hb1193b0_1.tar.bz2
+linux-64/cupy-7.4.0-py38h231ae29_1.tar.bz2
+linux-64/cupy-7.4.0-py38hd239d08_1.tar.bz2
+linux-64/cupy-7.4.0-py38h74c3a04_1.tar.bz2
+
+linux-64/cupy-7.4.0-py37h658377b_1.tar.bz2
+linux-64/cupy-7.4.0-py37h9c6dd92_1.tar.bz2
+linux-64/cupy-7.4.0-py37h0632833_1.tar.bz2
+linux-64/cupy-7.4.0-py37h940342b_1.tar.bz2
+
+linux-64/cupy-7.4.0-py36h5c369b2_1.tar.bz2
+linux-64/cupy-7.4.0-py36h273e724_1.tar.bz2
+linux-64/cupy-7.4.0-py36h4445f8d_1.tar.bz2
+linux-64/cupy-7.4.0-py36he883178_1.tar.bz2
+
+# v7.3.0 build 1
+linux-64/cupy-7.3.0-py38hb1193b0_1.tar.bz2
+linux-64/cupy-7.3.0-py38h231ae29_1.tar.bz2
+linux-64/cupy-7.3.0-py38hd239d08_1.tar.bz2
+linux-64/cupy-7.3.0-py38h74c3a04_1.tar.bz2
+
+linux-64/cupy-7.3.0-py37h940342b_1.tar.bz2
+linux-64/cupy-7.3.0-py37h9c6dd92_1.tar.bz2
+linux-64/cupy-7.3.0-py37h658377b_1.tar.bz2
+linux-64/cupy-7.3.0-py37h0632833_1.tar.bz2
+
+linux-64/cupy-7.3.0-py36h273e724_1.tar.bz2
+linux-64/cupy-7.3.0-py36he883178_1.tar.bz2
+linux-64/cupy-7.3.0-py36h4445f8d_1.tar.bz2
+linux-64/cupy-7.3.0-py36h5c369b2_1.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Added a link to the relevant issue in the PR description:
The bug is fixed in conda-forge/cupy-feedstock#55 and conda-forge/cupy-feedstock#56.

* [x] Pinged the team for the package.
ping @conda-forge/cupy
