### PR TITLE
Remove mesalib since it wasn't tagged with the correct OSX version

### DIFF
--- a/pkgs/mesalib_18.0.0_osx.txt
+++ b/pkgs/mesalib_18.0.0_osx.txt
@@ -1,0 +1,1 @@
+osx-64/mesalib-18.0.0-hb6cfc13_0.tar.bz2


### PR DESCRIPTION
Checklist:

Broken in: https://github.com/conda-forge/mesalib-feedstock/pull/26#issuecomment-614901653
Fixed in: https://github.com/conda-forge/mesalib-feedstock/pull/28

sorry this took so long @muryanto1 
cc @conda-forge/mesalib (i am part of the team too)

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.
<!
  For example if you are trying to mark a python package as broken.

      ping @conda-forge/python
!>
