### PR TITLE
Mark recent OpenJDK builds as broken

### DIFF
--- a/pkgs/openjdk.txt
+++ b/pkgs/openjdk.txt
@@ -1,0 +1,5 @@
+osx-64/openjdk-8.0.192-h0b31af3_1004.tar.bz2
+win-64/openjdk-8.0.192-1004.tar.bz2
+linux-64/openjdk-8.0.192-h516909a_1004.tar.bz2
+linux-ppc64le/openjdk-11.0.1-h08ffdf3_1019.tar.bz2
+linux-aarch64/openjdk-11.0.1-h600c080_1019.tar.bz2


### PR DESCRIPTION
These break `rjava` by putting `libjvm` into a non-standard location: https://github.com/conda-forge/openjdk-feedstock/issues/66

Note that for openjdk11, build 1019 did not run on Azure, so there are no builds for linux-/win-/osx-64 to be marked as broken.

Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.
      ping @conda-forge/openjdk @CJ-Wright 

PRs to fix the build:

- https://github.com/conda-forge/openjdk-feedstock/pull/70
- https://github.com/conda-forge/openjdk-feedstock/pull/69

