### PR TITLE
Remove broken abinit executables

### DIFF
--- a/pkgs/abinit.txt
+++ b/pkgs/abinit.txt
@@ -1,0 +1,5 @@
+linux-64/abinit-8.10.2-h279e56a_5.tar.bz2
+linux-64/abinit-8.10.2-h279e56a_3.tar.bz2
+linux-64/abinit-8.10.2-h279e56a_2.tar.bz2
+linux-64/abinit-8.10.2-h279e56a_1.tar.bz2
+linux-64/abinit-8.10.2-hbe17f75_0.tar.bz2


### PR DESCRIPTION
Checklist: @conda-forge/abinit 

Somehow the tests passed but when using the executable on services like mybinder they fail: 
https://github.com/jan-janssen/abinit-example - https://github.com/conda-forge/abinit-feedstock/issues/5 

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.


