### PR TITLE
Remove broken xeus 0.23.15

### DIFF
--- a/pkgs/xeus.txt
+++ b/pkgs/xeus.txt
@@ -1,0 +1,5 @@
+linux-aarch64/xeus-0.23.15-h4d8c418_0.tar.bz2
+linux-ppc64le/xeus-0.23.15-had093f3_0.tar.bz2
+linux-64/xeus-0.23.15-h4d8c418_0.tar.bz2
+win-64/xeus-0.23.15-h7ef1ec2_0.tar.bz2
+osx-64/xeus-0.23.15-ha1b3eb9_0.tar.bz2


### PR DESCRIPTION
Last release of xeus is not binray compatible, leading to crash of applications linking with it.
The release should be tagged as backward incompatible (even if it is compatible regarding the API).
