### PR TITLE
ENH mark sysroot 2.17 for linux-64 as broken

### DIFF
--- a/pkgs/sysroot.txt
+++ b/pkgs/sysroot.txt
@@ -1,0 +1,1 @@
+noarch/sysroot_linux-64-2.17-h3a0023d_2.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package. @conda-forge/linux-sysroot 
<!--
  For example if you are trying to mark a python package as broken.

      ping @conda-forge/python
--!>
