### PR TITLE
Remove broken SphinxDFT packages

### DIFF
--- a/pkgs/sphinxdft.txt
+++ b/pkgs/sphinxdft.txt
@@ -1,0 +1,6 @@
+linux-64/sphinxdft-2.6.1-h6ced99e_7.tar.bz2
+linux-64/sphinxdft-2.6.1-h6ced99e_8.tar.bz2
+linux-64/sphinxdft-2.6.1-h6ced99e_9.tar.bz2
+linux-64/sphinxdft-2.6.1-h0dc8829_10.tar.bz2
+linux-64/sphinxdft-2.6.1-h0dc8829_11.tar.bz2
+linux-64/sphinxdft-2.6.1-h7b8f8e9_12.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.

@conda-forge/sphinxdft 

Follow-up to https://github.com/conda-forge/cf-mark-broken/pull/48 

Discussed in: https://github.com/conda-forge/sphinxdft-feedstock/issues/15 

I had to add `CFLAGS="${CFLAGS}"`  and `CPPFLAGS="${CPPFLAGS}"` to make the executables work on systems other than the Azure container they were built in. 
