### PR TITLE
fix: accidently re-released 2.6 while pinning to newer versions

### DIFF
--- a/pkgs/vaex.txt
+++ b/pkgs/vaex.txt
@@ -1,0 +1,1 @@
+noarch/vaex-2.6.0-pyh9f0ad1d_0.tar.bz2


### PR DESCRIPTION
Without updating version:
https://github.com/conda-forge/vaex-feedstock/pull/26
Fix:
https://github.com/conda-forge/vaex-feedstock/pull/27