### PR TITLE
mark aiida-core=1.2.1 old builds as broken

### DIFF
--- a/pkgs/aiida-core.txt
+++ b/pkgs/aiida-core.txt
@@ -1,0 +1,12 @@
+linux-64/aiida-core-1.2.1-py37hc8dfbb8_0.tar.bz2
+linux-64/aiida-core-1.2.1-py38h32f6830_0.tar.bz2
+linux-64/aiida-core-1.2.1-py36h9f0ad1d_0.tar.bz2
+osx-64/aiida-core-1.2.1-py37hc8dfbb8_0.tar.bz2
+osx-64/aiida-core-1.2.1-py36h9f0ad1d_0.tar.bz2
+osx-64/aiida-core-1.2.1-py38h32f6830_0.tar.bz2
+linux-64/aiida-core-1.2.1-py38h32f6830_1.tar.bz2
+linux-64/aiida-core-1.2.1-py37hc8dfbb8_1.tar.bz2
+linux-64/aiida-core-1.2.1-py36h9f0ad1d_1.tar.bz2
+osx-64/aiida-core-1.2.1-py37hc8dfbb8_1.tar.bz2
+osx-64/aiida-core-1.2.1-py36h9f0ad1d_1.tar.bz2
+osx-64/aiida-core-1.2.1-py38h32f6830_1.tar.bz2


### PR DESCRIPTION
Checklist:

enforce dependency constraint introduced in https://github.com/conda-forge/aiida-core-feedstock/pull/34
ping @conda-forge/aiida-core

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.
<!--
  For example if you are trying to mark a python package as broken.

      ping @conda-forge/python
--!>
