### PR TITLE
ENH mark broken for symlinks

### DIFF
--- a/pkgs/sysroot.txt
+++ b/pkgs/sysroot.txt
@@ -1,0 +1,3 @@
+noarch/sysroot_linux-64-2.17-conda_cos7_variant_hf2e4eb1_5.tar.bz
+noarch/sysroot_linux-64-2.12-conda_variant_h77966d4_8.tar.bz2
+noarch/sysroot_linux-64-2.12-conda_cos6_variant_hb99331e_8.tar.bz2

--- a/pkgs/sysroot.txt
+++ b/pkgs/sysroot.txt
@@ -1,3 +1,3 @@
-noarch/sysroot_linux-64-2.17-conda_cos7_variant_hf2e4eb1_5.tar.bz
+noarch/sysroot_linux-64-2.17-conda_cos7_variant_hf2e4eb1_5.tar.bz2
 noarch/sysroot_linux-64-2.12-conda_variant_h77966d4_8.tar.bz2
 noarch/sysroot_linux-64-2.12-conda_cos6_variant_hb99331e_8.tar.bz2


### PR DESCRIPTION
Checklist:

* [ ] Added a link to the relevant issue in the PR description: the symlinks needed to be remade https://github.com/conda-forge/ctng-compilers-feedstock/pull/29
* [ ] Pinged the team for the package. @conda-forge/linux-sysroot 
