### PR TITLE
Build number 0 of simbody 3.7 is broken

### DIFF
--- a/pkgs/simbody.txt
+++ b/pkgs/simbody.txt
@@ -1,0 +1,3 @@
+win-64/simbody-3.7-h3dbd755_0.tar.bz2
+osx-64/simbody-3.7-h64ad5ed_0.tar.bz2
+linux-64/simbody-3.7-h5f743cb_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.
<!--
  For example if you are trying to mark a `foo` conda package as broken.

      ping @conda-forge/foo
--!>

I'm submitting the `opensim` package to conda-forge (https://github.com/conda-forge/staged-recipes#11894). This package depends on `simbody >=3.7`, but there are two builds of simbody 3.7 (https://anaconda.org/conda-forge/simbody/files): number 0 and number 1. The automated build is installing build 0, which has a bug in it (https://github.com/conda-forge/simbody-feedstock/issues/33). This PR marks build 0 as broken. Thank you to @wolfv, who suggested I make this PR.
<br><br>
ping @conda-forge/simbody 
<br><br>
What is the process for having this PRs reviewed? I am a maintainer of `simbody-feedstock`.