### PR TITLE
Mark builds with unpinned macOS SDK as broken

### DIFF
--- a/pkgs/root-migration-macos.txt
+++ b/pkgs/root-migration-macos.txt
@@ -1,0 +1,4 @@
+osx-64/root_numpy-4.8.0-py36h31ecf39_6.tar.bz2
+osx-64/root_numpy-4.8.0-py37h9b29bbb_6.tar.bz2
+osx-64/root_numpy-4.8.0-py38h4bdf021_6.tar.bz2
+osx-64/rapidsim-1.5-h5a1702a_3.tar.bz2


### PR DESCRIPTION
Closes https://github.com/conda-forge/root_numpy-feedstock/issues/15
Closes https://github.com/conda-forge/rapidsim-feedstock/issues/7

Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.
<!--
  For example if you are trying to mark a `foo` conda package as broken.

      ping @conda-forge/foo
--!>
