### PR TITLE
mark noarch/cdat_info-8.2.1.rc1-py_0.tar.bz2 to be broken

### DIFF
--- a/pkgs/broken.txt
+++ b/pkgs/broken.txt
@@ -1,0 +1,1 @@
+noarch/cdat_info-8.2.1.rc1-py_0.tar.bz2


### PR DESCRIPTION
Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [ ] Pinged the team for the package.
<!--
  For example if you are trying to mark a `foo` conda package as broken.

      ping @conda-forge/foo
--!>
https://github.com/conda-forge/cdat_info-feedstock/issues/22