### PR TITLE
Remove broken Cykhash package.

### DIFF
--- a/pkgs/cykhash.txt
+++ b/pkgs/cykhash.txt
@@ -1,0 +1,1 @@
+noarch/cykhash-1.0.2-pyhe1b5a44_0.tar.bz2


### PR DESCRIPTION
Removing broken Cykhash package build from conda-forge. More info here: https://github.com/conda-forge/cykhash-feedstock/pull/1

@conda-forge/cykhash 

Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.
<!--
  For example if you are trying to mark a `foo` conda package as broken.

      ping @conda-forge/foo
--!>
