### PR TITLE
Mark metric-learn 0.6.0 as broken

### DIFF
--- a/pkgs/metric-learn.txt
+++ b/pkgs/metric-learn.txt
@@ -1,0 +1,2 @@
+noarch/metric-learn-0.6.0-py_0.tar.bz2
+noarch/metric-learn-0.6.0-py_1.tar.bz2


### PR DESCRIPTION
v0.6.0 had missing requirements after dropping support for Python < 3.6
Users should install v0.6.2

https://github.com/scikit-learn-contrib/metric-learn/pull/299
https://github.com/scikit-learn-contrib/metric-learn/pull/300

@conda-forge/metric-learn 

Checklist:

* [x] Added a link to the relevant issue in the PR description.
* [x] Pinged the team for the package.

